### PR TITLE
Multiple sources

### DIFF
--- a/gitops_updater/handlers/argocd.py
+++ b/gitops_updater/handlers/argocd.py
@@ -48,7 +48,7 @@ class ArgoCDYamlFile:
             if 'source' in spec and spec['source'] is not None:
                 self.version = spec['source']['targetRevision']
                 self.segment = segment
-                self.use_sources = False
+                self.chart_source = spec['source']
                 return
 
             if 'sources' in spec and spec['sources'] is not None:
@@ -57,7 +57,6 @@ class ArgoCDYamlFile:
                         self.version = source['targetRevision']
                         self.segment = segment
                         self.chart_source = source
-                        self.use_sources = True
                         return
 
         raise Exception("Couldn't locate segment in yaml file")
@@ -66,10 +65,7 @@ class ArgoCDYamlFile:
         return semver.VersionInfo.parse(self.version)
 
     def update(self, version: str) -> str:
-        if self.use_sources:
-            self.chart_source['targetRevision'] = version
-        else:
-            self.segment['spec']['source']['targetRevision'] = version
+        self.chart_source['targetRevision'] = version
         stream = StringIO()
         self.yaml_loader.dump_all(self.yaml_content, stream)
         return stream.getvalue()

--- a/gitops_updater/handlers/argocd.py
+++ b/gitops_updater/handlers/argocd.py
@@ -44,9 +44,21 @@ class ArgoCDYamlFile:
             if segment['metadata'] is None or segment['metadata']['name'] != name:
                 continue
 
-            self.version = segment['spec']['source']['targetRevision']
-            self.segment = segment
-            return
+            spec = segment['spec']
+            if 'source' in spec and spec['source'] is not None:
+                self.version = spec['source']['targetRevision']
+                self.segment = segment
+                self.use_sources = False
+                return
+
+            if 'sources' in spec and spec['sources'] is not None:
+                for source in spec['sources']:
+                    if 'chart' in source and source['chart'] is not None:
+                        self.version = source['targetRevision']
+                        self.segment = segment
+                        self.chart_source = source
+                        self.use_sources = True
+                        return
 
         raise Exception("Couldn't locate segment in yaml file")
 
@@ -54,7 +66,10 @@ class ArgoCDYamlFile:
         return semver.VersionInfo.parse(self.version)
 
     def update(self, version: str) -> str:
-        self.segment['spec']['source']['targetRevision'] = version
+        if self.use_sources:
+            self.chart_source['targetRevision'] = version
+        else:
+            self.segment['spec']['source']['targetRevision'] = version
         stream = StringIO()
         self.yaml_loader.dump_all(self.yaml_content, stream)
         return stream.getvalue()

--- a/gitops_updater/handlers/argocd.py
+++ b/gitops_updater/handlers/argocd.py
@@ -47,7 +47,6 @@ class ArgoCDYamlFile:
             spec = segment['spec']
             if 'source' in spec and spec['source'] is not None:
                 self.version = spec['source']['targetRevision']
-                self.segment = segment
                 self.chart_source = spec['source']
                 return
 
@@ -55,7 +54,6 @@ class ArgoCDYamlFile:
                 for source in spec['sources']:
                     if 'chart' in source and source['chart'] is not None:
                         self.version = source['targetRevision']
-                        self.segment = segment
                         self.chart_source = source
                         return
 


### PR DESCRIPTION
ARGOCD support either a single source or multiple sources. 

Single source:

```yaml
spec:
  project: default

  source:
    repoURL: registry.icts.uva-hva.nl
    chart: integratieteam/applications/charts/integratieteam-openonderwijs-eventprocessor
    targetRevision: 1.41.2
```

Multiple sources:

```yaml
spec:
  project: default

  sources:
  - repoURL: https://gitlab.ic.uva.nl/integratieteam/platform/gitops.git
    ref: values
  - repoURL: registry.icts.uva-hva.nl
    chart: integratieteam/applications/charts/integratieteam-openonderwijs-api
    targetRevision: 2.39.34
```

Gitops updater only supported single sources. With this change it supports both where single source is the default.